### PR TITLE
Softcoded previously hardcoded path

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -39,7 +39,7 @@ const Adapter = {
     schema: true,
     debug: false,
     type: 'disk',
-    filename: '.tmp/db.sqlite',
+    filename: 'db.sqlite',
     path : '.tmp'
   },
 
@@ -83,7 +83,7 @@ const Adapter = {
         knex: Knex({
           client: 'sqlite3',
           connection: {
-            filename: connection.path + '/' + connection.identity + '.sqlite'
+            filename: connection.path + '/' + connection.filename
           },
           debug: process.env.WATERLINE_DEBUG_SQL || connection.debug
         })


### PR DESCRIPTION
For some reason, the original creator of this sqlite adapter chose to hardcode the path to database file. I am just trying to softcode it back